### PR TITLE
Remove Errant erc20OfInterest Segments

### DIFF
--- a/ethereum/compound/b2c.json
+++ b/ethereum/compound/b2c.json
@@ -156,72 +156,52 @@
             "contractName": "cCOMP",
             "selectors": {
                 "0x0e752702": {
-                    "erc20OfInterest": [
-                        "path.1"
-                    ],
+                    "erc20OfInterest": [],
                     "method": "RepayBorrow",
                     "plugin": "Compound"
                 },
                 "0x2608f818": {
-                    "erc20OfInterest": [
-                        "path.1"
-                    ],
+                    "erc20OfInterest": [],
                     "method": "repayBorrowBehalf",
                     "plugin": "Compound"
                 },
                 "0x56781388": {
-                    "erc20OfInterest": [
-                        "path.1"
-                    ],
+                    "erc20OfInterest": [],
                     "method": "castVote",
                     "plugin": "Compound"
                 },
                 "0x5c19a95c": {
-                    "erc20OfInterest": [
-                        "path.1"
-                    ],
+                    "erc20OfInterest": [],
                     "method": "delegate",
                     "plugin": "Compound"
                 },
                 "0x852a12e3": {
-                    "erc20OfInterest": [
-                        "path.1"
-                    ],
+                    "erc20OfInterest": [],
                     "method": "redeemUnderlying",
                     "plugin": "Compound"
                 },
                 "0xa0712d68": {
-                    "erc20OfInterest": [
-                        "path.1"
-                    ],
+                    "erc20OfInterest": [],
                     "method": "mint",
                     "plugin": "Compound"
                 },
                 "0xa9059cbb": {
-                    "erc20OfInterest": [
-                        "path.1"
-                    ],
+                    "erc20OfInterest": [],
                     "method": "transfer",
                     "plugin": "Compound"
                 },
                 "0xc5ebeaec": {
-                    "erc20OfInterest": [
-                        "path.1"
-                    ],
+                    "erc20OfInterest": [],
                     "method": "borrow",
                     "plugin": "Compound"
                 },
                 "0xdb006a75": {
-                    "erc20OfInterest": [
-                        "path.1"
-                    ],
+                    "erc20OfInterest": [],
                     "method": "redeem",
                     "plugin": "Compound"
                 },
                 "0xf5e3c462": {
-                    "erc20OfInterest": [
-                        "path.1"
-                    ],
+                    "erc20OfInterest": [],
                     "method": "liquidateBorrow",
                     "plugin": "Compound"
                 }


### PR DESCRIPTION
This patch removes errant `erc20OfInterest` segments added to cCOMP incorrectly. They had `path.1` which is not a data argument of these functions and is causing failures from Ledger users who are interacting with cCOMP.  This is high priority as it's actively blocking usage of Ledger for any interactions of cCOMP.